### PR TITLE
adding a contactURL to the api key signup form

### DIFF
--- a/key.md
+++ b/key.md
@@ -11,6 +11,7 @@ nav: basics
   var apiUmbrellaSignupOptions = {
     registrationSource: 'code-gov',
     apiKey: 'ELORrx8BmruIQg0kicvVjT0FonWUl4xGluJwEjiT',
+    contactUrl: 'https://github.com/GSA/code-gov-api/issues',
     exampleApiUrl: 'https://api.code.gov/repos?api_key={{api_key}}'
   };
 


### PR DESCRIPTION
This personalizes the `contact us` link that appears after a key is generated (and is included in the email that is sent) so that it leads to a [code.gov specific option](https://github.com/GSA/code-gov-api/issues), instead of the generic api.data.gov email address.  

If you'd rather they go to a different link or email address, [here's the documentation for changing it](https://github.com/18F/api.data.gov/wiki/User-Manual:-Agencies#linking-to-your-own-contactsupport-address).  