### PR TITLE
Add Google Tag Manager script to default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,15 @@
   <link rel="stylesheet" href="static/css/normalize.css">
   <link rel="stylesheet" href="static/css/style.css">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- We use Google Tag Manager to participate in the Federal Government's Digital Analytics Program (DAP). You can see the data for code.gov and other federal websites at analytics.usa.gov -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-5CKH6WC');</script>
+  <!-- End Google Tag Manager -->
+
   <!--[if lt IE 9]>
   <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->


### PR DESCRIPTION
**Summary**

This PR adds Google Tag Manager to the default layout (which is used by all of the pages) so that traffic on developers.code.gov can be sent to both the Digital Analytics Program dashboard (including analytics.usa.gov) as well as to the code.gov Google Analytics dashboard.